### PR TITLE
Free atr buffer on close

### DIFF
--- a/src/halse_se05x.c
+++ b/src/halse_se05x.c
@@ -616,6 +616,8 @@ static void halse_se05x_close(struct halse_dev *device)
 	dev->i2c_dev = NULL;
 	halgpio_close(dev->gpio_dev);
 	dev->gpio_dev = NULL;
+	free(dev->atr);
+	dev->atr = NULL;
 }
 
 /*


### PR DESCRIPTION
Currently allocated ATRs are not free when device is cloesed